### PR TITLE
Add Dockerfile and fix debug express logs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
+
+FROM node:12
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+EXPOSE 80
+ENV PORT=80
+
+CMD [ "npm", "start" ]

--- a/app.js
+++ b/app.js
@@ -6,6 +6,11 @@ const cors = require('cors')
 
 // create express web server app
 const app = express()
+
+// log requests to the terminal when running in a local debug setup
+if(process.env.NODE_ENV !== 'production')
+  app.use(logger('dev'))
+
 app.use(express.json())
 app.use(express.urlencoded({ extended: false }))
 app.use(cors())
@@ -48,10 +53,5 @@ app.use(function(err, req, res, next) {
   res.status(err.status || 500)
   res.send(err.message)
 })
-
-// log requests to the terminal when running in a local debug setup
-if(process.env.NODE_ENV !== 'production')
-  app.use(logger('dev'))
-
 
 module.exports = app


### PR DESCRIPTION
* Adds a simple Dockerfile based on https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
* Moves logging back to the top of the middleware chain. It wasn't working for me where it was.