### PR TITLE
Support absolute paths to local definitions on server

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -33,6 +33,7 @@ console.log('RHINO_COMPUTE_URL: ' + process.env.RHINO_COMPUTE_URL)
 
 // Routes for this app
 app.use('/example', express.static(__dirname + '/example'))
+app.get('/favicon.ico', (req, res) => res.status(200))
 app.use('/', require('./routes/index'))
 app.use('/definition', require('./routes/definition'))
 app.use('/solve', require('./routes/solve'))


### PR DESCRIPTION
Provide the utility to have the AppServer use definitions on it's file system outside of the specific appserver 'files' directory. This is proving to be useful for remote component work.