### PR TITLE
Add link to template to save source code

### DIFF
--- a/src/views/definition.hbs
+++ b/src/views/definition.hbs
@@ -52,6 +52,7 @@
                 </div>
                 {{/each}}
                 <div><button id="downloadButton" disabled>Download</button></div>
+                <div><a href="{{name}}" download="{{name}}.html">Save source code</a></div>
             </div>
 
             <div id="canvas"></div>


### PR DESCRIPTION
The html file that is downloaded can be copied to /example/ (for example!).