### PR TITLE
Set solve url dynamically, instead of with view engine

### DIFF
--- a/src/views/definition.hbs
+++ b/src/views/definition.hbs
@@ -165,7 +165,7 @@ function init() {
  */
 async function compute() {
   // construct url for GET /solve/definition.gh?name=value(&...)
-  const url = new URL('/solve/{{name}}', window.location.origin)
+  const url = new URL('/solve/' + data.definition, window.location.origin)
   Object.keys(data.inputs).forEach(key => url.searchParams.append(key, data.inputs[key]))
   console.log(url.toString())
   


### PR DESCRIPTION
Grasshopper file name set in one place - easier to tweak after "saving source code"